### PR TITLE
Configuración de AppDbContext y conexión a SQL Server en PedidoService

### DIFF
--- a/PedidoService/Data/AppDbContext.cs
+++ b/PedidoService/Data/AppDbContext.cs
@@ -1,0 +1,14 @@
+namespace PedidoService.Data
+{
+    using Microsoft.EntityFrameworkCore;
+    using PedidoService.Models;
+
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<Pedido> Pedidos { get; set; }
+    }
+}

--- a/PedidoService/Program.cs
+++ b/PedidoService/Program.cs
@@ -13,8 +13,11 @@ namespace PedidoService
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
+            // Add DbContext configuration
+            builder.Services.AddDbContext<AppDbContext>(options =>
+     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
-            var app = builder.Build();
+            builder.Services.AddControllers();
 
             // Configure the HTTP request pipeline.
             if (app.Environment.IsDevelopment())


### PR DESCRIPTION
- Se creó la clase AppDbContext en la carpeta Data, heredando de DbContext.
- Se agregó el constructor con DbContextOptions<AppDbContext> para la configuración.
- Se añadió la propiedad DbSet<Pedido> Pedidos para mapear la entidad Pedido.
- Se registró el AppDbContext en el contenedor de servicios (Program.cs) usando SQL Server y la cadena de conexión DefaultConnection.
- Se mantuvo la configuración de Swagger y controladores en el Program.cs.